### PR TITLE
Fix axes.prop_cycle syntax in all matplotlib style files

### DIFF
--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-bright-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-bright-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-bright-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-bright-paper.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-bright-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-bright-poster.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-bright-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-bright-talk.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-colorblind-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-colorblind-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-colorblind-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-colorblind-paper.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-colorblind-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-colorblind-poster.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-colorblind-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-colorblind-talk.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-dark-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-dark-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-dark-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-dark-paper.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-dark-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-dark-poster.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-dark-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-dark-talk.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-deep-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-deep-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-deep-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-deep-paper.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-deep-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-deep-poster.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-deep-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-deep-talk.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-muted-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-muted-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-muted-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-muted-paper.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-muted-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-muted-poster.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-muted-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-muted-talk.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-pastel-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-pastel-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-pastel-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-pastel-paper.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-pastel-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-pastel-poster.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-pastel-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-dark-pastel-talk.mplstyle
@@ -8,7 +8,7 @@ axes.facecolor: #EAEAF2
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-bright-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-bright-notebook.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-bright-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-bright-paper.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-bright-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-bright-poster.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-bright-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-bright-talk.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-colorblind-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-colorblind-notebook.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-colorblind-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-colorblind-paper.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-colorblind-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-colorblind-poster.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-colorblind-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-colorblind-talk.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-dark-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-dark-notebook.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-dark-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-dark-paper.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-dark-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-dark-poster.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-dark-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-dark-talk.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-deep-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-deep-notebook.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-deep-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-deep-paper.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-deep-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-deep-poster.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-deep-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-deep-talk.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-muted-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-muted-notebook.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-muted-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-muted-paper.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-muted-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-muted-poster.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-muted-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-muted-talk.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-pastel-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-pastel-notebook.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-pastel-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-pastel-paper.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-pastel-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-pastel-poster.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-pastel-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-darkgrid-pastel-talk.mplstyle
@@ -9,7 +9,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-bright-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-bright-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-bright-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-bright-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-bright-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-bright-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-bright-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-bright-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-colorblind-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-colorblind-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-colorblind-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-colorblind-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-colorblind-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-colorblind-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-colorblind-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-colorblind-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-dark-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-dark-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-dark-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-dark-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-dark-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-dark-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-dark-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-dark-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-deep-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-deep-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-deep-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-deep-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-deep-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-deep-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-deep-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-deep-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-muted-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-muted-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-muted-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-muted-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-muted-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-muted-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-muted-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-muted-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-pastel-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-pastel-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-pastel-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-pastel-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-pastel-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-pastel-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-pastel-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-ticks-pastel-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-bright-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-bright-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-bright-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-bright-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-bright-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-bright-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-bright-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-bright-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-colorblind-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-colorblind-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-colorblind-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-colorblind-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-colorblind-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-colorblind-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-colorblind-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-colorblind-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-dark-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-dark-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-dark-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-dark-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-dark-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-dark-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-dark-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-dark-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-deep-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-deep-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-deep-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-deep-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-deep-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-deep-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-deep-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-deep-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-muted-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-muted-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-muted-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-muted-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-muted-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-muted-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-muted-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-muted-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-pastel-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-pastel-notebook.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-pastel-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-pastel-paper.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-pastel-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-pastel-poster.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-white-pastel-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-white-pastel-talk.mplstyle
@@ -7,7 +7,7 @@ axes.edgecolor: .15
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-bright-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-bright-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-bright-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-bright-paper.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-bright-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-bright-poster.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-bright-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-bright-talk.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #023eff, #ff7c00, #1ac938, #e8000b, #8b2be2, #9f4800, #f14cc1, #a3a3a3, #ffc400, #00d7ff
+axes.prop_cycle: cycler('color', ['023eff', 'ff7c00', '1ac938', 'e8000b', '8b2be2', '9f4800', 'f14cc1', 'a3a3a3', 'ffc400', '00d7ff'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-colorblind-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-colorblind-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-colorblind-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-colorblind-paper.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-colorblind-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-colorblind-poster.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-colorblind-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-colorblind-talk.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #0173b2, #de8f05, #029e73, #d55e00, #cc78bc, #ca9161, #fbafe4, #949494, #ece133, #56b4e9
+axes.prop_cycle: cycler('color', ['0173b2', 'de8f05', '029e73', 'd55e00', 'cc78bc', 'ca9161', 'fbafe4', '949494', 'ece133', '56b4e9'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-dark-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-dark-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-dark-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-dark-paper.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-dark-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-dark-poster.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-dark-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-dark-talk.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #001c7f, #b1400d, #12711c, #8c0800, #591e71, #592f0d, #a23582, #3c3c3c, #b8850a, #006374
+axes.prop_cycle: cycler('color', ['001c7f', 'b1400d', '12711c', '8c0800', '591e71', '592f0d', 'a23582', '3c3c3c', 'b8850a', '006374'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-deep-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-deep-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-deep-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-deep-paper.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-deep-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-deep-poster.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-deep-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-deep-talk.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #4c72b0, #dd8452, #55a868, #c44e52, #8172b3, #937860, #da8bc3, #8c8c8c, #ccb974, #64b5cd
+axes.prop_cycle: cycler('color', ['4c72b0', 'dd8452', '55a868', 'c44e52', '8172b3', '937860', 'da8bc3', '8c8c8c', 'ccb974', '64b5cd'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-muted-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-muted-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-muted-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-muted-paper.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-muted-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-muted-poster.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-muted-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-muted-talk.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #4878d0, #ee854a, #6acc64, #d65f5f, #956cb4, #8c613c, #dc7ec0, #797979, #d5bb67, #82c6e2
+axes.prop_cycle: cycler('color', ['4878d0', 'ee854a', '6acc64', 'd65f5f', '956cb4', '8c613c', 'dc7ec0', '797979', 'd5bb67', '82c6e2'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-pastel-notebook.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-pastel-notebook.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 12.0
 axes.linewidth: 1.25
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 12.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-pastel-paper.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-pastel-paper.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 9.600000000000001
 axes.linewidth: 1.0
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 9.600000000000001
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-pastel-poster.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-pastel-poster.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 24.0
 axes.linewidth: 2.5
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 24.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif

--- a/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-pastel-talk.mplstyle
+++ b/src/mplstyles_seaborn/styles/seaborn-v0_8-whitegrid-pastel-talk.mplstyle
@@ -8,7 +8,7 @@ axes.grid: True
 axes.labelcolor: .15
 axes.labelsize: 18.0
 axes.linewidth: 1.875
-axes.prop_cycle: #a1c9f4, #ffb482, #8de5a1, #ff9f9b, #d0bbff, #debb9b, #fab0e4, #cfcfcf, #fffea3, #b9f2f0
+axes.prop_cycle: cycler('color', ['a1c9f4', 'ffb482', '8de5a1', 'ff9f9b', 'd0bbff', 'debb9b', 'fab0e4', 'cfcfcf', 'fffea3', 'b9f2f0'])
 axes.titlesize: 18.0
 font.sans-serif: Source Sans 3, Arial, DejaVu Sans, Liberation Sans, Bitstream Vera Sans, sans-serif
 font.family: sans-serif


### PR DESCRIPTION
## Summary

This PR fixes a critical matplotlib parsing error where `axes.prop_cycle` was using comma-separated hex colors instead of proper cycler syntax.

**Problem**: Style files had `axes.prop_cycle: #0173b2, #de8f05, ...` which caused matplotlib to throw "Bad value" and "invalid cycler construction" errors.

**Solution**: Updated all 120 style files to use correct cycler syntax: `cycler('color', ['0173b2', 'de8f05', ...])`

## Changes

- Updated `fix_styles.py` to generate proper cycler syntax
- Fixed all 120 style files across all style/palette/context combinations  
- Removed `#` prefix from hex colors as required by matplotlib
- Ensured colors are properly quoted in cycler format

## Test plan

- [x] Verified style files load without errors: `plt.style.use('seaborn-v0_8-whitegrid-colorblind-talk')`
- [x] Tested that colors are correctly applied to plots
- [x] Confirmed all 120 style files follow consistent format
- [x] Validated against matplotlib's expected cycler syntax

🤖 Generated with [Claude Code](https://claude.ai/code)