### PR TITLE
Enhance GitHub Actions workflow for reliable setuptools-scm operation

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,6 +21,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history for setuptools-scm to work correctly
+          fetch-tags: true  # Fetch all tags for proper version detection
 
       - uses: actions/setup-python@v5
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ build-backend = "setuptools.build_meta"
 [dependency-groups]
 dev = [
     "build>=1.2.2.post1",
+    "setuptools-scm>=8.3.1",
     "twine>=6.1.0",
 ]
 


### PR DESCRIPTION
## Overview

This PR enhances the GitHub Actions deployment workflow to work reliably with setuptools-scm dynamic versioning by ensuring the CI environment has access to complete git history and tags.

## Changes Made

### GitHub Actions Workflow Improvements
- **Add **: Retrieves full git history instead of shallow checkout
- **Add **: Ensures all repository tags are available to setuptools-scm
- These changes allow setuptools-scm to correctly identify when building from exact release tags

### Development Dependencies  
- **Add ** to dev dependency group for consistent local development
- Ensures version generation works identically across development and CI environments

## Technical Context

### Problem Solved
The default GitHub Actions checkout behavior uses shallow clones () and doesn't fetch tags (). This causes setuptools-scm to generate development versions like  instead of clean release versions like  when building from exact tags.

### Solution Details
The combination of:
-  - Provides complete git history for context
-  - Makes all repository tags available for version calculation

Gives setuptools-scm the complete information needed to accurately determine:
- When we're building exactly at a release tag → clean version (e.g., )
- When we're building from development commits → development version (e.g., )

## Testing

- ✅ Workflow syntax is valid
- ✅ setuptools-scm dependency properly configured
- ✅ Changes are minimal and focused on the specific issue
- 🔄 Will be validated through the automated deployment process when merged

## Impact

This fix enables reliable automated PyPI publishing by ensuring setuptools-scm generates appropriate version numbers in CI/CD environments, completing the dynamic versioning and automated deployment infrastructure established in PR #13.

---

🤖 Generated with [Claude Code](https://claude.ai/code)