### PR TITLE
Fix GitHub Actions release workflow to checkout exact tag

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }}  # Checkout the exact tag that triggered the release
           fetch-depth: 0  # Fetch full history for setuptools-scm to work correctly
           fetch-tags: true  # Fetch all tags for proper version detection
 


### PR DESCRIPTION
## Summary
- Fix GitHub Actions release workflow to checkout the exact tag instead of HEAD
- Ensures setuptools-scm generates correct version numbers for releases

## Problem
The previous v0.2.5 release was deployed to PyPI as `0.2.6.dev0` because the workflow was checking out HEAD (which was ahead of the tag) instead of the exact release tag.

## Solution
- Add `ref: ${{ github.ref }}` to the checkout action in release workflow
- This ensures the workflow builds from the exact tagged commit
- setuptools-scm will then generate the clean version number (e.g., `0.2.5`)

## Test plan
- [x] Verified workflow change targets correct ref
- [ ] Will recreate v0.2.5 release after merge to test fix

🤖 Generated with [Claude Code](https://claude.ai/code)