### PR TITLE
Simplify setuptools-scm for clean release versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,3 @@ exclude_lines = [
 
 [tool.setuptools_scm]
 write_to = "src/mplstyles_seaborn/_version.py"
-version_scheme = "guess-next-dev"
-local_scheme = "no-local-version"
-fallback_version = "0.0.0"


### PR DESCRIPTION
Simplify setuptools-scm to use default behavior for reliable version generation