### PR TITLE
Fix setuptools-scm to prevent local version suffixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,4 @@ exclude_lines = [
 
 [tool.setuptools_scm]
 write_to = "src/mplstyles_seaborn/_version.py"
+local_scheme = "no-local-version"


### PR DESCRIPTION
Add no-local-version scheme to prevent +commit.date suffixes rejected by PyPI